### PR TITLE
debug `Module not found: Can't resolve 'fs'`

### DIFF
--- a/components/Play.tsx
+++ b/components/Play.tsx
@@ -19,7 +19,7 @@ const Play = ({ response }: PlayProps) => {
   const [loading, setLoading] = useState(true);
   const [isCorrect, setIsCorrect] = useState(false);
   const [userInput, setUserInput] = useState("");
-  const scorePoster = Container.getInstance().getScorePoster();
+  // const scorePoster = Container.getInstance().getScorePoster();
 
   const currentWord = response.words[currentIndex];
 
@@ -47,7 +47,7 @@ const Play = ({ response }: PlayProps) => {
         level: level,
       };
 
-      scorePoster.post(scoreRequest);
+      // scorePoster.post(scoreRequest);
     }
 
     setUserInput("");


### PR DESCRIPTION
Module not found: Can't resolve 'fs' のエラーがでる原因は、サーバーサイドのNode.jsモジュールである`fs`（ファイルシステム）をクライアントサイドでインポートしようとしていることです。`fs`モジュールはブラウザ環境では使用できません。

- 該当のfsを呼んでいるコードは共通ファイルで定義されているが、呼び出し元によって実行がSSRかCSRか決まる。
- 元はPage.tsxのサーバーコンポーネントのみで呼ばれていたので動くが、今回はPlayコンポーネント内で呼んでいるので壊れた